### PR TITLE
Add chat search and concurrency

### DIFF
--- a/flashpoint_core/flashpoint_base.py
+++ b/flashpoint_core/flashpoint_base.py
@@ -1,8 +1,7 @@
-#!/usr/bin/python
-
-from IPython.core.magic import (Magics, magics_class, line_magic, cell_magic, line_cell_magic)
+from IPython.core.magic import (Magics, magics_class, line_cell_magic)
 from flashpoint_core._version import __desc__
 import jupyter_integrations_utility as jiu
+
 
 @magics_class
 class Flashpoint(Magics):
@@ -13,7 +12,6 @@ class Flashpoint(Magics):
     debug = False
     # {name_str}_base is used for first load
     # {name_str}_full is used after first load
-
 
     def __init__(self, shell, debug=False, *args, **kwargs):
         super(Flashpoint, self).__init__(shell, debug=debug)
@@ -37,7 +35,7 @@ class Flashpoint(Magics):
             # This is where add our base version
             self.shell.user_ns['jupyter_loaded_integrations'][self.name_str] = f"{self.name_str}_base"
 
-    # This returns the description 
+    # This returns the description
     def retCustomDesc(self):
         return __desc__
 
@@ -45,7 +43,7 @@ class Flashpoint(Magics):
 
     @line_cell_magic
     def flashpoint(self, line, cell=None):
-        if not self.name_str in self.shell.user_ns['jupyter_loaded_integrations']:
+        if self.name_str not in self.shell.user_ns['jupyter_loaded_integrations']:
             jiu.displayMD(f"**[ ! ]** Somehow we got here and {self.name_str} is not in loaded integrations - Unpossible")
         else:
             if self.shell.user_ns['jupyter_loaded_integrations'][self.name_str] != f"{self.name_str}_base":
@@ -59,4 +57,3 @@ class Flashpoint(Magics):
                 self.shell.ex(full_load)
                 self.shell.user_ns['jupyter_loaded_integrations'][self.name_str] = f"{self.name_str}_full"
                 self.shell.run_cell_magic(self.name_str, line, cell)
-

--- a/flashpoint_core/flashpoint_full.py
+++ b/flashpoint_core/flashpoint_full.py
@@ -143,30 +143,32 @@ class Flashpoint(Integration):
 
         cell_magic_table = ("| Cell Magic | Description |\n"
                             "| ---------- | ----------- |\n"
-                            "| %%flashpoint instance<br>--help | Display usage syntax help for `%%flashpoint` \
+                            "| %%flashpoint prod<br>--help | Display usage syntax help for `%%flashpoint` \
                                 cell magics |\n"
                             "| %%flashpoint instance<br>command --help | Display usage syntax for a specific \
                                 command |\n"
                             "| %%flashpoint instance<br>search_media -l 25 -s 2024-01-01 -e 2024-01-31 --images \
-                                <br>'wells fargo' | Search Flashpoint media for the specified start and end dates \
-                                for posts containing the exact phrase 'wells fargo', limited to 25 results, and \
-                                include the images in the results. The date_end parameter will default to 'now' \
-                                if not specified. |\n"
-                            "| %%flashpoint instance<br>get_image<br>the _source.media.storage_uri from a particular \
-                                media in your results | Retrieve an image from the Flashpoint API by the \
-                                `_source.media.storage_uri` field |\n")
+                                -q \"wells fargo\" | Search Flashpoint media for the specified start and end \
+                                dates for posts containing the exact phrase \"wells fargo\", limited to 25 results, \
+                                and include the images in the results. The date_end parameter will default to \
+                                'now' if not specified. If you'd like to do some more complex searching, \
+                                like \|\"wells fargo\" \|checking, just make sure to wrap single quotes around it, \
+                                like so:<br>`'\|\"wells fargo\" \|checking'` |\n"
+                            "| %%flashpoint instance<br>get_image -u _source.media.storage_uri | Retrieve an image \
+                                from the Flashpoint API by the `_source.media.storage_uri` field of a result. |\n"
+                            "| %%flashpoint instance<br>search_chat -l 5 -s 2024-01-01 -e 2024-01-31 -q \
+                                \"search term\" | Search Flashpoint chat messages for the specified start and end \
+                                dates for posts containing the exact phrase \"search term\", limited to 5 results. If \
+                                you'd like to do some more complex searching, like \|\"wells fargo\" \|checking, just \
+                                make sure to wrap single quotes around it:<br>`'\|\"wells fargo\" \|checking'` |\n"
+                            "| %%flashpoint instance<br>search_chat -l 10 -s 2024-01-01 -u list_of_search_terms | \
+                                Search Flashpoint chat messages starting from 2024-01-01 until now for posts \
+                                containing keywords from an existing list in Jupyter. Simply replace \
+                                `list_of_search_terms` with the name of the list containing your search terms<br>\
+                                **NOTE** If the list contains multiple search terms, this will run asynchronously \
+                                and concurrently, so like really fast. |\n")
 
-        line_magic_helper_text = (f"\n## Running {magic_name} line magics\n"
-                                  "-------------------------------\n"
-                                  f"\n#### To see a line magic's command syntax, type `%mongo --help`\n"
-                                  "\n### Line magic examples\n"
-                                  "-----------------------\n")
-
-        line_magic_table = ("| Line Magic | Description |\n"
-                            "| ---------- | ----------- |\n"
-                            "| | |\n")
-
-        help_out = cell_magic_helper_text + cell_magic_table + line_magic_helper_text + line_magic_table
+        help_out = cell_magic_helper_text + cell_magic_table
 
         return help_out
 

--- a/flashpoint_core/flashpoint_full.py
+++ b/flashpoint_core/flashpoint_full.py
@@ -28,7 +28,7 @@ class Flashpoint(Integration):
 
     myopts = {}
     myopts["flashpoint_conn_default"] = ["default", "Default instance to connect with"]
-    myopts["flashpoint_verify_ssl"] = [False, "Toggle this to True to verify SSL connections"]
+    myopts["flashpoint_verify_ssl"] = [True, "Toggle this to True to verify SSL connections"]
     myopts["flashpoint_disable_ssl_warnings"] = [True, "Toggle this to False to receive warnings \
         for SSL; this will be _very_ noisy!"]
     myopts["flashpoint_max_retries"] = [3, "The number of attempts to retry a request before failing."]
@@ -236,7 +236,6 @@ class Flashpoint(Integration):
                     status = "Success"
 
             except Exception as e:
-                raise
                 jiu.display_error(f"**[ ! ]** Error during execution: {e}")
                 dataframe = None
                 status = f"Failure - {e}"

--- a/flashpoint_utils/flashpoint_api.py
+++ b/flashpoint_utils/flashpoint_api.py
@@ -196,7 +196,11 @@ class FlashpointAPI:
                         progress_bar.update(1)
                     return query, response, 0
             elif response.status_code == 200:
-                hits_count = len(response.json()["hits"]["hits"])
+                if "application/json" in response.headers.get("Content-Type"):
+                    hits_count = len(response.json()["hits"]["hits"])
+                else:
+                    hits_count = 1
+
                 if progress_bar:
                     progress_bar.update(1)
                 return query, response, hits_count
@@ -279,7 +283,17 @@ class FlashpointAPI:
             "headers": headers
         }
 
-        response = self._fetch(item)
+        with tqdm(total=1,
+                  unit="request",
+                  desc="Processing",
+                  bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} Elapsed time:{elapsed} Total Results: {postfix[0]}]",
+                  postfix=[0]) as progress_bar:
+
+            response = self._fetch(item, progress_bar)
+
+            # Add total hits to the progress bar and update it
+            progress_bar.postfix[0] = response[2]
+            progress_bar.update(0)
 
         if images:
             # update the response object with response.content for each image
@@ -329,6 +343,18 @@ class FlashpointAPI:
             "payload": payload,
             "headers": headers
         }
+
+        with tqdm(total=1,
+                  unit="request",
+                  desc="Processing",
+                  bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} Elapsed time:{elapsed} Total Results: {postfix[0]}]",
+                  postfix=[0]) as progress_bar:
+
+            response = self._fetch(item, progress_bar)
+
+            # Add total hits to the progress bar and update it
+            progress_bar.postfix[0] = response[2]
+            progress_bar.update(0)
 
         return self._fetch(item)
 

--- a/flashpoint_utils/flashpoint_api.py
+++ b/flashpoint_utils/flashpoint_api.py
@@ -333,16 +333,16 @@ class FlashpointAPI:
         return self._fetch(item)
 
     def search_chat(self, query, limit, date_start, date_end, *args, **kwargs):
-        """_summary_
+        """Search Flashpoint for chat messages that contain one or more keywords.
 
         Args:
-            query (_type_): _description_
-            limit (_type_): _description_
-            date_start (_type_): _description_
-            date_end (_type_): _description_
+            query (list): a list of search terms to search for
+            limit (int): the number of results to return for each search term
+            date_start (str): the start date represented in YYYY-MM-DD
+            date_end (str): the end date represented in YYYY-MM-DD
 
         Returns:
-            _type_: _description_
+            tup: (search term, response object, hit count)
         """
 
         url = f"https://{self.host}/all/search"

--- a/flashpoint_utils/helper_functions.py
+++ b/flashpoint_utils/helper_functions.py
@@ -1,7 +1,9 @@
 import argparse
 import base64
 from datetime import datetime
+from IPython import get_ipython
 
+ipy = get_ipython()
 
 def create_b64_image_string(raw_image):
     """Convert a raw bytes image to a base64 string"""
@@ -15,11 +17,18 @@ def format_b64_image_for_dataframe(b64_image_string):
     return f"<img src='data:image/jpeg;base64,{b64_image_string}' />"
 
 
-def valid_date_format(date):
-    if date.lower() == 'now':
+def valid_date_format(date_from_argparse):
+    if date_from_argparse.lower() == 'now':
         return datetime.now().date()
     try:
-        return datetime.strptime(date, "%Y-%m-%d").date()
+        return datetime.strptime(date_from_argparse, "%Y-%m-%d").date()
     except ValueError:
-        msg = f"Not a valid date: {date}"
-        raise argparse.ArgumentTypeError(msg)
+        raise argparse.ArgumentTypeError(f"Not a valid date: {date_from_argparse}")
+
+
+def valid_list(user_list):
+    if user_list not in ipy.user_ns:
+        raise argparse.ArgumentTypeError(f'The list "{user_list}" is not currently loaded. Are you \
+            sure that it exists and the call has been loaded?')
+    else:
+        return ipy.user_ns[user_list]


### PR DESCRIPTION
# What's changed?

- Complete overhaul of magic command usage syntax to make it (hopefully) easier for the user
- All Flashpoint API calls funnel through a `_fetch` function for consistency and control
- The `_fetch` function accepts a new user option `max_retries` and will gracefully fail if that amount of `HTTP 429` responses are received
- The `_fetch` function properly handles `HTTP 429` from the Flashpoint API by exponentially backing each retry. For example, the first 429 will back off 3 seconds, then 9 seconds, then 27 seconds, all the way up to the `max_retries`
- Added a new `search_chat` function that will accept a search term or a list of search terms depending on what the user passes to the magic command (i.e. `--query <term>` or `--list list_of_terms`.
- The `search_chat` function will also accept a Python list of search terms loaded into the kernel, and will gracefully let the user know if it doesn't exist
- The `search_chat` uses a new `_concurrent_fetches` function that will, you guessed it, concurrently run HTTP requests to the Flashpoint API
- `user_input_parser` uses new `helper_functions` for user input validation (for dates and to read lists in memory)
- Examples have been updated in the docs