### PR TITLE
Get image concurrency

### DIFF
--- a/flashpoint_core/flashpoint_full.py
+++ b/flashpoint_core/flashpoint_full.py
@@ -223,7 +223,8 @@ class Flashpoint(Integration):
                 parsed_response = self.response_parser._handler(parsed_input["input"]["command"], response)
 
                 if parsed_input["input"]["command"] == "get_image":
-                    display(HTML(parsed_response))
+                    for img in parsed_response:
+                        display(HTML(img[1]))
                     dataframe = None
                     status = "Success - No Results"
 
@@ -238,6 +239,7 @@ class Flashpoint(Integration):
                     status = "Success"
 
             except Exception as e:
+                raise
                 jiu.display_error(f"**[ ! ]** Error during execution: {e}")
                 dataframe = None
                 status = f"Failure - {e}"

--- a/flashpoint_utils/api_response_parser.py
+++ b/flashpoint_utils/api_response_parser.py
@@ -71,6 +71,7 @@ class ResponseParser:
             flattened_response -- a flattened list of dictionaries to be
                 used in a dataframe
         """
+
         original_query = response[0]
         response_json = response[1].json()
         hits = response_json["hits"]["hits"]
@@ -115,8 +116,13 @@ class ResponseParser:
             Returns:
             An HTML-ready b64 string of the image
         """
-        b64_img_data = create_b64_image_string(response[1].content)
-        return format_b64_image_for_dataframe(b64_img_data)
+        images_list = []
+        for img in response:
+            b64_img_data = create_b64_image_string(img[1].content)
+            formatted_image = format_b64_image_for_dataframe(b64_img_data)
+            images_list.append([img[0], formatted_image])
+
+        return images_list
 
     def search_chat(self, responses):
 

--- a/flashpoint_utils/user_input_parser.py
+++ b/flashpoint_utils/user_input_parser.py
@@ -47,7 +47,7 @@ class UserInputParser(ArgumentParser):
         # Subparser for "get_image" command
         self.parser_get_image = self.cell_subparsers.add_parser("get_image", help="Get an image from the Flashpoint \
             API by the _source.media.storage_uri JSON path")
-        self.parser_get_image.add_argument("-u", "--uri", required=True, help="The value of the \
+        self.parser_get_image.add_argument("-u", "--uri", action="append", required=True, help="The value of the \
             _source.media.storage_uri field of the image to retrieve")
 
         # Subparser for "search_chat" command


### PR DESCRIPTION
# What's changed?
- completely refactored how `get_images` runs.
- refactored how `search_media` retrieves images for each "hit" to run concurrently using `self._concurrent_fetches`
- updated and added commenting so that other people (and I) know how this works