### PR TITLE
fixed query parsing with single quote encapsulation

### DIFF
--- a/flashpoint_utils/flashpoint_api.py
+++ b/flashpoint_utils/flashpoint_api.py
@@ -30,9 +30,12 @@ class FlashpointAPI:
         Search Flashpoint for posts that contain media. Perform a subsequent query
         to retrieve the actual image, and add that to the data before returning it
         if the user asks for them.
+
     get_image(query, **kwargs):
         Retrieve a single image from the Flashpoint API, by _source.media.storage_uri
 
+    search_chat(query, **kwargs):
+        Search Flashpoint for chat messages that contain one or more keywords.
     """
     def __init__(self, host, token, proxies=None, verify=True, max_retries=3, max_workers=10):
         self.session = niquests.Session()

--- a/flashpoint_utils/helper_functions.py
+++ b/flashpoint_utils/helper_functions.py
@@ -32,3 +32,12 @@ def valid_list(user_list):
             sure that it exists and the call has been loaded?')
     else:
         return ipy.user_ns[user_list]
+
+
+def remove_quotes(user_query):
+    """If the user encapsulated their query with single quotes (they'd do this
+        if they're trying to run a complex query), remove the quotes so we can
+        avoid HTTP 400 errors (aka pass a valid query to the Flashpoint API)"""
+    if user_query.startswith("'") and user_query.endswith("'"):
+        return user_query[1:-1]
+    return user_query

--- a/flashpoint_utils/helper_functions.py
+++ b/flashpoint_utils/helper_functions.py
@@ -34,7 +34,7 @@ def valid_list(user_list):
         return ipy.user_ns[user_list]
 
 
-def remove_quotes(user_query):
+def valid_query(user_query):
     """If the user encapsulated their query with single quotes (they'd do this
         if they're trying to run a complex query), remove the quotes so we can
         avoid HTTP 400 errors (aka pass a valid query to the Flashpoint API)"""

--- a/flashpoint_utils/user_input_parser.py
+++ b/flashpoint_utils/user_input_parser.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser, BooleanOptionalAction
 import re
 import shlex
 from flashpoint_utils.flashpoint_api import FlashpointAPI
-from flashpoint_utils.helper_functions import valid_date_format, valid_list
+from flashpoint_utils.helper_functions import valid_date_format, valid_list, remove_quotes
 
 
 class UserInputParser(ArgumentParser):
@@ -40,7 +40,7 @@ class UserInputParser(ArgumentParser):
             earliest date to look for results")
         self.parser_search_media.add_argument("-e", "--date_end", type=valid_date_format, default="now",
                                               required=False, help="latest date to look for results; default is 'now'")
-        self.parser_search_media.add_argument("-q", "--query", type=str, required=True, help="your query")
+        self.parser_search_media.add_argument("-q", "--query", type=remove_quotes, required=True, help="your query")
         self.parser_search_media.add_argument("--images", action=BooleanOptionalAction, required=False, help="include \
             image thumbnails in results")
 

--- a/flashpoint_utils/user_input_parser.py
+++ b/flashpoint_utils/user_input_parser.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser, BooleanOptionalAction
 import re
 import shlex
 from flashpoint_utils.flashpoint_api import FlashpointAPI
-from flashpoint_utils.helper_functions import valid_date_format, valid_list, remove_quotes
+from flashpoint_utils.helper_functions import valid_date_format, valid_list, valid_query
 
 
 class UserInputParser(ArgumentParser):
@@ -40,7 +40,7 @@ class UserInputParser(ArgumentParser):
             earliest date to look for results")
         self.parser_search_media.add_argument("-e", "--date_end", type=valid_date_format, default="now",
                                               required=False, help="latest date to look for results; default is 'now'")
-        self.parser_search_media.add_argument("-q", "--query", type=remove_quotes, required=True, help="your query")
+        self.parser_search_media.add_argument("-q", "--query", type=valid_query, required=True, help="your query")
         self.parser_search_media.add_argument("--images", action=BooleanOptionalAction, required=False, help="include \
             image thumbnails in results")
 


### PR DESCRIPTION
# What was the problem?
When a user has a complex query that has double quotes, they must encapsulate the query in single quotes in the cell magic. Prior to this commit, we simply pass the user's query to the Flashpoint API but this is a VERY BAD REQUEST and is PUNISHED SEVERELY with an HTTP 400 (BAD REQUEST, BAD).

# What's changed?
- Added a new helper function to check for single quote encapsulation (i.e. - `'+something "exact string"'`), remove them, and return the query string
- Updated the flashpoint_api.py file to include the search_chat function in the documentation